### PR TITLE
Develop - Dando soporte a que se manejen caracteres UTF - 8

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,41 +5,53 @@
 #include <set>
 #include <fstream>
 #include <sstream>
-#include <cctype>
-
+#include <locale>
+#include <codecvt>
+#include <windows.h>
 // Función hash djb2
-unsigned long hash_djb2(const std::string& word) {
+unsigned long hash_djb2(const std::string &word)
+{
     unsigned long hash_value = 5381;
-    for (char c : word) {
-        hash_value = ((hash_value << 5) + hash_value) + c;  // Aplicación del algoritmo djb2
+    for (char c : word)
+    {
+        hash_value = ((hash_value << 5) + hash_value) + c;
     }
     return hash_value;
 }
 
-// Función para procesar archivos de texto y devolver el contenido de cada archivo con un ID único
-std::vector<std::pair<int, std::string>> readDocuments(const std::vector<std::string>& filepaths) {
+// Función para procesar archivos de texto
+std::vector<std::pair<int, std::string>> readDocuments(const std::vector<std::string> &filepaths)
+{
+    // Ingresa cada documento con id y contenido en el vector de pares
     std::vector<std::pair<int, std::string>> documents;
     int doc_id = 1;
-    for (const auto& filepath : filepaths) {
-        std::ifstream file(filepath);  // Abrir archivo
-        if (file.is_open()) {
+    for (const auto &filepath : filepaths)
+    {
+        std::ifstream file(filepath, std::ios::binary);
+        if (file.is_open())
+        {
             std::stringstream buffer;
-            buffer << file.rdbuf();  // Leer contenido del archivo en un stringstream
-            documents.emplace_back(doc_id++, buffer.str());  // Agregar contenido con ID único al vector de documentos
+            buffer << file.rdbuf();
+            documents.emplace_back(doc_id++, buffer.str());
         }
     }
     return documents;
 }
 
-// Función para guardar los resultados de búsqueda en un archivo de salida
-void saveResults(const std::string& filepath, const std::vector<std::pair<std::string, std::set<int>>>& lookup_table) {
-    std::ofstream outfile(filepath);  // Abrir archivo de salida
-    if (outfile.is_open()) {
-        for (const auto& pair : lookup_table) {
-            if (!pair.first.empty()) {  // Asegurarse de que la palabra no esté vacía
-                outfile << "(" << pair.first << ", ";  // Escribir la palabra en el archivo
-                for (int doc_id : pair.second) {
-                    outfile << doc_id << " ";  // Escribir cada ID de documento asociado a la palabra
+// Función para guardar los resultados en un archivo de salida
+void saveResults(const std::string &filepath, const std::vector<std::pair<std::string, std::set<int>>> &lookup_table)
+{
+    std::ofstream outfile(filepath);
+    if (outfile.is_open())
+    {
+        for (const auto &pair : lookup_table)
+        {
+            if (!pair.first.empty())
+            {
+                outfile << "(" << pair.first << ", ";
+                for (int doc_id : pair.second)
+                {
+                    outfile << doc_id << " ";
                 }
                 outfile << ")\n";
             }
@@ -48,65 +60,161 @@ void saveResults(const std::string& filepath, const std::vector<std::pair<std::s
 }
 
 // Función para guardar los valores hash en un archivo de salida
-void saveHashValues(const std::string& filepath, const std::unordered_map<std::string, unsigned long>& hash_values) {
-    std::ofstream outfile(filepath);  // Abrir archivo de salida
-    if (outfile.is_open()) {
-        for (const auto& pair : hash_values) {
-            outfile << "\"" << pair.first << "\" usando djb2 es " << pair.second << ".\n";  // Escribir la palabra y su valor hash
+void saveHashValues(const std::string &filepath, const std::unordered_map<std::string, unsigned long> &hash_values)
+{
+    std::ofstream outfile(filepath);
+    if (outfile.is_open())
+    {
+        for (const auto &pair : hash_values)
+        {
+            outfile << "\"" << pair.first << "\" usando djb2 es " << pair.second << ".\n";
         }
     }
 }
 
 // Función de búsqueda por índice invertido
-std::set<int> searchWord(const std::string& word, const std::vector<std::pair<std::string, std::set<int>>>& lookup_table) {
-    unsigned long position = hash_djb2(word) % lookup_table.size();  // Calcular la posición basada en el hash de la palabra
-    if (lookup_table[position].first == word) {  // Si la palabra coincide con la encontrada en esa posición
-        return lookup_table[position].second;  // Devolver los IDs de documento asociados a esa palabra
+std::set<int> searchWord(const std::string &word, const std::vector<std::pair<std::string, std::set<int>>> &lookup_table)
+{
+    unsigned long position = hash_djb2(word) % lookup_table.size();
+    if (lookup_table[position].first == word)
+    {
+        return lookup_table[position].second;
     }
-    return {};  // Devolver conjunto vacío si la palabra no está presente
+    return {};
 }
 
-int main() {
+// Si es que preposición o algún otro tipo de palabra que no se debe considerar
+boolean isprep(std::string word)
+{
+    std::string preps[] = {"a","se", "al", "ante", "del", "cabe", "con", "sino", "de", "desde", "si", "su", "en", "entre", "sus", "hasta", "mío", "para", "sí", "yó", "por", "la", "sin", "so", "sobre", "tras", "él", "no", "lo", "un", "y", "o", "ni", "que", "pero", "aunque", "sino", "si", "el", "ello", "iba", "sido", "cada", "los", "ya", "cual"};
+    // size of preps
+    int size = sizeof(preps) / sizeof(preps[0]);
+    for (int i = 0; i < size; i++)
+    {
+        if (word == preps[i] || word.length() == 1)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+// Método que devuelve una lista de archivos en una ruta path
+std::vector<std::string> getFilesInDirectory(const std::string &path = ".")
+{
+    std::vector<std::string> archivosTxt;
+
+    WIN32_FIND_DATAA findFileData;
+    HANDLE hFind = FindFirstFileA((path + "\\*.txt").c_str(), &findFileData);
+
+    if (hFind != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            archivosTxt.push_back(findFileData.cFileName);
+        } while (FindNextFileA(hFind, &findFileData));
+
+        FindClose(hFind);
+    }
+    else
+    {
+        // Error al abrir el path
+        std::cerr << "Error al abrir el directorio: " << GetLastError() << std::endl;
+    }
+
+    return archivosTxt;
+}
+
+// Función de búsqueda por índice invertido
+std::set<int> searchWordMap(const std::string &word, const std::unordered_map<std::string, std::set<int>> &lookup_table)
+{
+    auto it = lookup_table.find(word);
+    if (it != lookup_table.end())
+    {
+        return it->second;
+    }
+    return {};
+}
+
+int main()
+{
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+
+    // Configurar wcin y wcout para trabajar con UTF-8
+    std::wcin.imbue(std::locale(std::locale(), new std::codecvt_utf8<wchar_t>));
+    std::wcout.imbue(std::locale(std::locale(), new std::codecvt_utf8<wchar_t>));
+
     // Lista de archivos de entrada
     std::vector<std::string> filepaths = {"file1.txt", "file2.txt", "file3.txt"};
+    // std::vector<std::string> filepaths = getFilesInDirectory("./txt");
+    // print filepaths
+    // for (int i = 0; i < filepaths.size(); i++)
+    // {  
+    //     std::wcout << std::wstring(filepaths[i].begin(), filepaths[i].end()) << std::endl;
+    // }
 
     // Leer documentos de los archivos de entrada
     std::vector<std::pair<int, std::string>> mapper_output = readDocuments(filepaths);
 
-    std::unordered_map<std::string, std::set<int>> intermediate_output;  // Mapa para almacenar palabras y sus IDs de documentos
-    std::unordered_map<std::string, unsigned long> hash_values;  // Mapa para almacenar valores hash de palabras
+    std::unordered_map<std::string, std::set<int>> intermediate_output;
+    std::unordered_map<std::string, unsigned long> hash_values;
 
-    // Mapper
-    for (const auto& pair : mapper_output) {
+        std::wcout << L"Archivos de entrada: " << std::endl;
+    // Mapper - Cada palabra será asignada a una lista de archivos
+    for (const auto &pair : mapper_output)
+    {
         int doc_id = pair.first;
         std::string document = pair.second;
         std::string word;
-        for (char c : document) {
-            if (isspace(c)) {  // Si el carácter es un espacio, se termina la palabra actual
-                if (!word.empty()) {
-                    intermediate_output[word].insert(doc_id);  // Insertar palabra y su ID de documento en el mapa
-                    hash_values[word] = hash_djb2(word);  // Calcular y guardar el valor hash de la palabra
-                    word.clear();  // Limpiar la palabra para la siguiente
+        for (char c : document)
+        {
+            if (isspace(c) || ispunct(c))
+            {
+                if (!word.empty())
+                { // termino una palabra
+                    if (!isprep(word))
+                    {
+                        intermediate_output[word].insert(doc_id);
+                        hash_values[word] = hash_djb2(word);
+                        // std::wcout << "Palabra aceptada: " << std::wstring(word.begin(), word.end()) << std::endl;
+                    }
+                    word.clear();
+                    
                 }
-            } else {
-                word += tolower(c);  // Convertir el carácter a minúscula y añadirlo a la palabra actual
+            }
+            else
+            {
+                word += tolower(static_cast<unsigned char>(c));
             }
         }
-        if (!word.empty()) {  // Si queda una palabra al final del documento
-            intermediate_output[word].insert(doc_id);  // Insertarla en el mapa
-            hash_values[word] = hash_djb2(word);  // Calcular y guardar su valor hash
+        if (!word.empty() && !isprep(word))
+        {
+            intermediate_output[word].insert(doc_id);
+            hash_values[word] = hash_djb2(word);
+            // std::wcout << "Palabra aceptada:" << std::wstring(word.begin(), word.end()) << std::endl;
         }
     }
 
     // Reducer
-    const unsigned long table_size = intermediate_output.size();  // Tamaño del índice invertido
-    std::vector<std::pair<std::string, std::set<int>>> lookup_table(table_size);  // Vector para almacenar el índice invertido
+    const unsigned long table_size = intermediate_output.size();
+    // print size
+    std::wcout << L"table_size: " << table_size << std::endl;
+    std::vector<std::pair<std::string, std::set<int>>> lookup_table(table_size);
 
-    for (const auto& pair : intermediate_output) {
-        const std::string& word = pair.first;
-        const std::set<int>& doc_ids = pair.second;
-        unsigned long position = hash_djb2(word) % table_size;  // Calcular posición basada en el hash de la palabra
-        lookup_table[position] = std::make_pair(word, doc_ids);  // Almacenar la palabra y sus IDs de documentos en el índice invertido
+    for (const auto &pair : intermediate_output)
+    {
+        const std::string &word = pair.first;
+        const std::set<int> &doc_ids = pair.second;
+        unsigned long position = hash_djb2(word) % table_size;
+        if (!lookup_table[position].first.empty())
+        {
+            // Resolver colisiones con encadenamiento
+            while (!lookup_table[position].first.empty())
+            {
+                position = (position + 1) % table_size;
+            }
+        }
+        lookup_table[position] = std::make_pair(word, doc_ids);
     }
 
     // Guardar los resultados en un archivo de salida
@@ -115,19 +223,27 @@ int main() {
     saveHashValues("hash_values.txt", hash_values);
 
     // Solicitar al usuario que ingrese una palabra para buscar
-    std::string search_word;
-    std::cout << "Ingrese la palabra a buscar: ";
-    std::cin >> search_word;
+    std::wcout << L"Ingrese la palabra a buscar: ";
+    std::wstring search_word;
+    std::getline(std::wcin, search_word);
+    std::wcout << L"Palabra ingresada: " << search_word << std::endl;
+    // Convertir la palabra de búsqueda a std::string
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
+    std::string search_word_str = converter.to_bytes(search_word);
 
-    // Búsqueda
-    std::set<int> result = searchWord(search_word, lookup_table);
+    // Búsqueda con vector y entero
+    // std::set<int> result = searchWord(search_word_str, lookup_table);
+    std::set<int> result = searchWordMap(search_word_str, intermediate_output);
 
     // Mostrar resultados de la búsqueda
-    std::cout << "Documentos que contienen la palabra \"" << search_word << "\": ";
-    for (int doc_id : result) {
-        std::cout << doc_id << " ";
+    std::wcout << L"Documentos que contienen la palabra \"" << search_word << L"\": ";
+    std::wcout << result.size() << L" documento(s)" << std::endl;
+    std::wcout << L"Archivos ";
+    for (int doc_id : result)
+    {
+        std::wcout << std::wstring(filepaths[doc_id - 1].begin(), filepaths[doc_id - 1].end()) << L" ";
     }
-    std::cout << std::endl;
+    std::wcout << std::endl;
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <unordered_map>
+#include <unordered_set>
 #include <string>
 #include <vector>
 #include <set>
@@ -86,16 +87,14 @@ std::set<int> searchWord(const std::string &word, const std::vector<std::pair<st
 // Si es que preposición o algún otro tipo de palabra que no se debe considerar
 boolean isprep(std::string word)
 {
-    std::string preps[] = {"a","se", "al", "ante", "del", "cabe", "con", "sino", "de", "desde", "si", "su", "en", "entre", "sus", "hasta", "mío", "para", "sí", "yó", "por", "la", "sin", "so", "sobre", "tras", "él", "no", "lo", "un", "y", "o", "ni", "que", "pero", "aunque", "sino", "si", "el", "ello", "iba", "sido", "cada", "los", "ya", "cual"};
-    // size of preps
-    int size = sizeof(preps) / sizeof(preps[0]);
-    for (int i = 0; i < size; i++)
-    {
-        if (word == preps[i] || word.length() == 1)
-        {
-            return true;
-        }
-    }
+    // Conjunto de preposiciones para reconocer
+    std::unordered_set<std::string> avoided_words = {
+        "a", "se", "al", "ante", "del", "cabe", "con", "sino", "de", "desde", "si", "su",
+        "en", "entre", "sus", "hasta", "mío", "para", "sí", "yó", "por", "la", "sin",
+        "so", "sobre", "tras", "él", "no", "lo", "un", "y", "o", "ni", "que", "pero",
+        "aunque", "sino", "si", "el", "ello", "iba", "sido", "cada", "los", "ya", "cual"};
+    if (avoided_words.count(word) > 0)
+        return true;
     return false;
 }
 // Método que devuelve una lista de archivos en una ruta path
@@ -149,7 +148,7 @@ int main()
     // std::vector<std::string> filepaths = getFilesInDirectory("./txt");
     // print filepaths
     // for (int i = 0; i < filepaths.size(); i++)
-    // {  
+    // {
     //     std::wcout << std::wstring(filepaths[i].begin(), filepaths[i].end()) << std::endl;
     // }
 
@@ -159,7 +158,7 @@ int main()
     std::unordered_map<std::string, std::set<int>> intermediate_output;
     std::unordered_map<std::string, unsigned long> hash_values;
 
-        std::wcout << L"Archivos de entrada: " << std::endl;
+    std::wcout << L"Archivos de entrada: " << std::endl;
     // Mapper - Cada palabra será asignada a una lista de archivos
     for (const auto &pair : mapper_output)
     {
@@ -179,7 +178,6 @@ int main()
                         // std::wcout << "Palabra aceptada: " << std::wstring(word.begin(), word.end()) << std::endl;
                     }
                     word.clear();
-                    
                 }
             }
             else


### PR DESCRIPTION
Se plantea una modificación a gran parte del código:
- Acepta caracteres como á, é, í, ó, ú y ñ
- Para ñ no aceptaba el hasheo, por la función hashdbj2, por tal motivo, se creó otro método que busca directamente en el mapa
- Añadido un método para buscar archivos txt en determinado path
- Se añadió el reconocimiento de puntuación o cuando es una preposición o palabra a evitar, dejando solo las palabras clave
- Se trata de añadir información a la salida para entender que es lo que sucedió